### PR TITLE
Fix initial render when opening index.html

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -497,9 +497,18 @@ const styles = {
   endDesc:{ opacity:0.95, lineHeight:1.6, marginBottom:8 }
 };
 
-document.addEventListener("DOMContentLoaded", () => {
+let hasRendered = false;
+function renderApp(){
+  if (hasRendered) return;
   const rootEl = document.getElementById("root");
   if (!rootEl) return;
+  hasRendered = true;
   const root = ReactDOM.createRoot(rootEl);
   root.render(<App />);
-});
+}
+
+if (document.readyState === "loading"){
+  document.addEventListener("DOMContentLoaded", renderApp, { once:true });
+} else {
+  renderApp();
+}


### PR DESCRIPTION
## Summary
- ensure the React app renders immediately even if the DOM is already parsed by defining a reusable render function
- guard against double renders and add a once-only DOMContentLoaded listener when needed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e12a33e04883209eab2bf9f36222eb