### PR TITLE
Adjust intro blur timing

### DIFF
--- a/index.html
+++ b/index.html
@@ -370,7 +370,7 @@ function TitleScreen({onStart}){
   };
 
   const overlayVisible = introPhase === "typing" || introPhase === "fadeout";
-  const baseBlur = introPhase === "typing" ? "blur(18px)" : introPhase === "fadeout" ? "blur(6px)" : "none";
+  const baseBlur = introPhase === "fadeout" ? "blur(6px)" : "none";
   const buttonLabel = hasIntroStarted ? "게임 시작" : "START";
   const buttonDisabled = introPhase === "typing" || introPhase === "fadeout";
 


### PR DESCRIPTION
## Summary
- remove the background blur from the title screen while the intro text is typing so the artwork stays sharp

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e13e0c0ff083209821ab2752118acd