### PR TITLE
Add skip option and delay intro start button appearance

### DIFF
--- a/index.html
+++ b/index.html
@@ -324,6 +324,7 @@ function TitleScreen({onStart}){
   const [finalRendered, setFinalRendered] = useState("");
   const [finalCharIndex, setFinalCharIndex] = useState(0);
   const [finalTypingDone, setFinalTypingDone] = useState(false);
+  const finalButtonDelayMs = 2000;
 
   const playTypingSound = useCallback(() => {
     const base = typingAudioRef.current;
@@ -424,7 +425,7 @@ function TitleScreen({onStart}){
       }, 55);
       return () => clearTimeout(timeout);
     }
-    const timeout = setTimeout(() => setFinalTypingDone(true), 320);
+    const timeout = setTimeout(() => setFinalTypingDone(true), finalButtonDelayMs);
     return () => clearTimeout(timeout);
   }, [introPhase, finalCharIndex, finalLine, finalTypingDone, playTypingSound]);
 
@@ -463,6 +464,25 @@ function TitleScreen({onStart}){
           backgroundColor: introPhase === "final" ? "rgba(6,9,17,0.92)" : "rgba(4,6,14,0.96)",
           pointerEvents: "auto"
         }}>
+          {hasIntroStarted && (
+            <button
+              onClick={onStart}
+              style={{
+                position: "absolute",
+                top: 24,
+                right: 28,
+                padding: "8px 16px",
+                fontWeight: 700,
+                fontSize: 14,
+                borderRadius: 999,
+                border: "1px solid rgba(255,255,255,0.3)",
+                background: "rgba(15,23,42,0.7)",
+                color: "#f8fafc",
+                cursor: "pointer",
+                boxShadow: "0 6px 18px rgba(0,0,0,0.35)"
+              }}
+            >Skip</button>
+          )}
           {introPhase === "typing" ? (
             <div style={styles.introBox}>
               {introLines.map((line, idx) => {


### PR DESCRIPTION
## Summary
- add a Skip control during the intro overlay to allow jumping straight into the game
- delay the appearance of the 출근하기 button until two seconds after the final intro line finishes typing

## Testing
- playwright screenshot of the intro overlay

------
https://chatgpt.com/codex/tasks/task_e_68e14938288c8320b71fbf61cb379488