### PR TITLE
Add Green Juice VN puzzle segment

### DIFF
--- a/green-juice-game.html
+++ b/green-juice-game.html
@@ -1,0 +1,1502 @@
+
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Green Juice Game Segment</title>
+    <style>
+      #demo-wrapper {
+        min-height: 100vh;
+        background: linear-gradient(180deg, #05070f, #0d1120);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 24px;
+        box-sizing: border-box;
+      }
+      #demo-wrapper h1 {
+        color: #f1f5f9;
+        font-family: "Pretendard", "Segoe UI", system-ui, -apple-system, sans-serif;
+        margin-bottom: 16px;
+        text-align: center;
+      }
+      #demo-card {
+        width: min(100%, 960px);
+        background: rgba(15, 23, 42, 0.92);
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        border-radius: 18px;
+        padding: 20px;
+        box-shadow: 0 20px 60px rgba(15, 23, 42, 0.45);
+      }
+    </style>
+  </head>
+  <body>
+    <div id="demo-wrapper">
+      <div id="demo-card">
+        <h1>Green Juice Game Segment</h1>
+        <div id="game-root"></div>
+      </div>
+    </div>
+    <script>
+
+(function (global) {
+  const NAMESPACE = "GreenJuiceGame";
+  if (global[NAMESPACE]) {
+    console.warn("GreenJuiceGame already defined. Overwriting.");
+  }
+
+  const PUZZLES = {
+    pairmatch: {
+      title: "라벨 해독",
+      description:
+        "라벨에 숨겨진 기호와 의미를 짝지어야 합니다. 두 장씩 뒤집어 같은 조합을 모두 찾으세요.",
+      timeLimit: 60,
+      evidence: "label_scan",
+      successScene: "act1_result",
+      failureScene: "act1_intro",
+      hint:
+        "알파벳 뒤에 붙은 점의 개수가 영양소의 순서를 암시합니다. 같은 점 수를 먼저 찾아보세요.",
+    },
+    slider: {
+      title: "냉장고 슬라이더",
+      description:
+        "푸른 주스 병들의 위치를 재배열하세요. 기호 순서가 'PUREE' 가 되도록 이동하면 됩니다.",
+      timeLimit: 75,
+      evidence: "gel_capsule",
+      successScene: "act2_result",
+      failureScene: "act2_fridge",
+      hint:
+        "왼쪽에서 오른쪽으로 'P-U-R-E-E' 를 만들면 됩니다. 가장 오른쪽 병을 고정하고 나머지를 맞춰보세요.",
+    },
+    rhythm: {
+      title: "회의 파형",
+      description:
+        "회의 음성 파형을 복구하려면 박자에 맞춰 탭하세요. 표시가 켜졌을 때 120ms 안에 버튼을 눌러야 합니다.",
+      timeLimit: 60,
+      evidence: "voice_loop",
+      successScene: "act3_result",
+      failureScene: "act3_meeting",
+      hint:
+        "표시가 꺼지기 직전에 누르는 것이 안전합니다. 첫 박자를 놓치지 마세요.",
+    },
+    circuit: {
+      title: "덕트 회로",
+      description:
+        "푸른 노드를 따라 전류를 흘려보내세요. 경로는 A에서 F까지 이어져야 합니다.",
+      timeLimit: 90,
+      evidence: "scale_chip",
+      successScene: "act4_result",
+      failureScene: "act4_duct",
+      hint:
+        "A에서 시작해 C를 거쳐 F로 향하는 경로를 우선 살펴보세요. 빛나는 노드를 이어보세요.",
+    },
+  };
+
+  const EVIDENCE = {
+    label_scan: { name: "라벨 스캔", weight: 1.0, reliability: 0.7 },
+    gel_capsule: { name: "젤 캡슐", weight: 1.2, reliability: 0.8 },
+    scale_chip: { name: "비늘 조각", weight: 0.8, reliability: 0.6 },
+    voice_loop: { name: "음성 반복", weight: 1.0, reliability: 0.75 },
+    memo_note: { name: "메모", weight: 1.1, reliability: 0.9 },
+  };
+
+  const SCENES = {
+    act1_intro: {
+      speaker: "보라",
+      text: "“클렌즈 3일 차라 머리가 맑아져요.”",
+      choices: [
+        {
+          text: "라벨을 스캔한다",
+          puzzleKey: "pairmatch",
+        },
+      ],
+    },
+    act1_result: {
+      speaker: "나",
+      text: "“라벨… 영양성분 대신 기호?”",
+      choices: [
+        {
+          text: "증거를 정리한다",
+          effect: { addMemo: true },
+          goto: "act2_fridge",
+        },
+      ],
+    },
+    act2_fridge: {
+      speaker: "보라",
+      text: "“냉장고는 손대지 않는 게 좋아요. 온도 조절이 예민하거든요.”",
+      choices: [
+        {
+          text: "병 배열을 조작한다",
+          puzzleKey: "slider",
+        },
+        {
+          text: "잠시 숨을 고른다 (정신력 +1)",
+          effect: { sanity: 1 },
+          goto: "act2_fridge",
+        },
+      ],
+    },
+    act2_result: {
+      speaker: "나",
+      text: "병 사이에 숨겨둔 젤 캡슐을 발견했다. 식품용이 아니다. 의심이 더해진다.",
+      choices: [
+        {
+          text: "회의실로 향한다",
+          goto: "act3_meeting",
+        },
+      ],
+    },
+    act3_meeting: {
+      speaker: "보라",
+      text: "회의실에서는 녹음기가 계속 돌아간다. 파형이 이상하게 반복된다.",
+      choices: [
+        {
+          text: "파형을 재조정한다",
+          puzzleKey: "rhythm",
+        },
+        {
+          text: "지켜본다 (정신력 -1)",
+          effect: { sanity: -1 },
+          goto: "act3_meeting",
+        },
+      ],
+    },
+    act3_result: {
+      speaker: "나",
+      text: "음성 반복 패턴이 정상 회의록과 다르다. 누군가가 루프를 주입하고 있었다.",
+      choices: [
+        {
+          text: "정수기 쪽으로 간다",
+          goto: "act4_duct",
+        },
+      ],
+    },
+    act4_duct: {
+      speaker: "보라",
+      text: "정수기 뒤 덕트는 빛나고 있다. 푸른 배선들이 어지럽게 얽혀 있다.",
+      choices: [
+        {
+          text: "푸른 노드를 연결한다",
+          puzzleKey: "circuit",
+        },
+      ],
+    },
+    act4_result: {
+      speaker: "나",
+      text: "배선 사이에서 비늘 조각과 함께 기록된 메모를 찾았다. '감시자는 투명해져라'.",
+      choices: [
+        {
+          text: "보라와 대면한다",
+          goto: "final_confront",
+        },
+      ],
+    },
+    final_confront: {
+      speaker: "보라",
+      text: "“당신도 곧 맑아질 거예요. 한 잔만 마시면.”",
+      choices: [
+        {
+          text: "증거를 정리해 보여준다",
+          goto: "ending_check",
+        },
+        {
+          text: "숨겨둔 메모를 찢는다 (정신력 -2)",
+          effect: { sanity: -2 },
+          goto: "ending_check",
+        },
+      ],
+    },
+    ending_good: {
+      speaker: "시스템",
+      text: "보라는 주스 대신 물을 마셨다. 푸른 눈빛이 흐려지고 진짜 동맹들이 나타난다.",
+      choices: [
+        {
+          text: "엔딩을 기록한다",
+          effect: function () {
+            finishGame("good");
+          },
+        },
+      ],
+    },
+    ending_neutral: {
+      speaker: "시스템",
+      text: "의심은 충분했지만 결정적 순간에 보라를 놓쳤다. 라운지는 잠시 안전하지만, 내일은 다를지 모른다.",
+      choices: [
+        {
+          text: "엔딩을 기록한다",
+          effect: function () {
+            finishGame("neutral");
+          },
+        },
+      ],
+    },
+    ending_bad: {
+      speaker: "시스템",
+      text: "정신력이 무너졌다. 푸른 주스가 목을 타고 흐를 때, 진실은 비늘로 덮였다.",
+      choices: [
+        {
+          text: "엔딩을 기록한다",
+          effect: function () {
+            finishGame("bad");
+          },
+        },
+      ],
+    },
+
+  const SCENE_DAYS = {
+    act1_intro: 1,
+    act1_result: 1,
+    act2_fridge: 2,
+    act2_result: 2,
+    act3_meeting: 3,
+    act3_result: 3,
+    act4_duct: 4,
+    act4_result: 4,
+    final_confront: 4,
+  };
+
+  let STATE = null;
+  let mountOptions = null;
+  let rootEl = null;
+  let styleEl = null;
+  let startTimestamp = null;
+  let activePuzzle = null;
+  let countdownInterval = null;
+  let beatTimeout = null;
+  let rhythmAnimation = null;
+  const timeouts = new Set();
+
+  function initState() {
+    STATE = {
+      day: 1,
+      maxDay: 4,
+      sanity: 5,
+      suspicion: 0,
+      evidence: new Set(),
+      hintUsed: 0,
+      sceneId: "act1_intro",
+      log: [],
+      stats: { fails: 0, hints: 0, timeSpent: 0 },
+    };
+  }
+
+  function ensureRoot() {
+    if (!rootEl) {
+      throw new Error("GreenJuiceGame: mount() must be called before start().");
+    }
+  }
+
+  function resolveContainer(containerOrSelector) {
+    if (typeof containerOrSelector === "string") {
+      return document.querySelector(containerOrSelector);
+    }
+    return containerOrSelector || null;
+  }
+
+  function mount(options) {
+    destroy();
+    const opts = options || {};
+    const container = resolveContainer(opts.container);
+    if (!container) {
+      throw new Error("GreenJuiceGame: valid container is required.");
+    }
+
+    mountOptions = {
+      onEnd: typeof opts.onEnd === "function" ? opts.onEnd : null,
+      assets: opts.assets || null,
+      flags: opts.flags || {},
+      handoff: opts.handoff || null,
+    };
+
+    initState();
+
+    rootEl = document.createElement("div");
+    rootEl.id = "gx-root";
+    rootEl.innerHTML = `
+      <div id="gx-layer">
+        <div id="gx-hud">
+          <div class="gx-meter">
+            <span class="gx-label">Day</span>
+            <span class="gx-value" id="gx-day"></span>
+          </div>
+          <div class="gx-meter">
+            <span class="gx-label">Sanity</span>
+            <div class="gx-bar"><div class="gx-bar-fill" id="gx-sanity-bar"></div></div>
+            <span class="gx-value" id="gx-sanity"></span>
+          </div>
+          <div class="gx-meter">
+            <span class="gx-label">Suspicion</span>
+            <div class="gx-bar"><div class="gx-bar-fill" id="gx-suspicion-bar"></div></div>
+            <span class="gx-value" id="gx-suspicion"></span>
+          </div>
+          <div class="gx-meter">
+            <span class="gx-label">Evidence</span>
+            <span class="gx-value" id="gx-evidence-count"></span>
+          </div>
+          <button type="button" class="gx-btn" id="gx-log-toggle">로그</button>
+        </div>
+        <div id="gx-vn">
+          <div id="gx-name"></div>
+          <div id="gx-text"></div>
+          <div id="gx-choices"></div>
+        </div>
+        <div id="gx-puzzle" class="gx-hidden">
+          <div id="gx-puzzle-backdrop"></div>
+          <div id="gx-puzzle-body">
+            <div id="gx-puzzle-header">
+              <div>
+                <h2 id="gx-puzzle-title"></h2>
+                <p id="gx-puzzle-desc"></p>
+              </div>
+              <div id="gx-puzzle-meta">
+                <span id="gx-puzzle-timer"></span>
+                <button type="button" class="gx-btn" id="gx-puzzle-hint">힌트</button>
+                <button type="button" class="gx-btn" id="gx-puzzle-reset">리셋</button>
+              </div>
+            </div>
+            <div id="gx-puzzle-content"></div>
+          </div>
+        </div>
+        <div id="gx-log" class="gx-hidden">
+          <div id="gx-log-panel">
+            <div id="gx-log-header">
+              <h3>사건 로그</h3>
+              <button type="button" class="gx-btn" id="gx-log-close">닫기</button>
+            </div>
+            <div id="gx-log-entries"></div>
+          </div>
+        </div>
+        <div id="gx-toast"></div>
+      </div>
+    `;
+
+    container.appendChild(rootEl);
+    injectStyles();
+    wireHUD();
+    updateHUD();
+  }
+
+  function injectStyles() {
+    const css = `
+      #gx-root {
+        font-family: 'Pretendard', 'Noto Sans KR', 'Apple SD Gothic Neo', system-ui, -apple-system, sans-serif;
+        color: #f3f4f6;
+        position: relative;
+      }
+      #gx-layer {
+        position: relative;
+        background: radial-gradient(120% 120% at 50% 0%, rgba(37, 99, 235, 0.14), rgba(15, 23, 42, 0.88));
+        border-radius: 18px;
+        padding: 24px;
+        box-sizing: border-box;
+        min-height: 420px;
+        box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
+        overflow: hidden;
+      }
+      #gx-hud {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        align-items: center;
+        justify-content: flex-start;
+        padding-bottom: 18px;
+      }
+      #gx-hud .gx-meter {
+        display: flex;
+        flex-direction: column;
+        min-width: 80px;
+        gap: 4px;
+        background: rgba(15, 23, 42, 0.55);
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        padding: 8px 10px;
+        border-radius: 12px;
+      }
+      #gx-hud .gx-label {
+        font-size: 12px;
+        letter-spacing: 0.2em;
+        text-transform: uppercase;
+        opacity: 0.7;
+      }
+      #gx-hud .gx-value {
+        font-weight: 700;
+        font-size: 16px;
+      }
+      #gx-hud .gx-bar {
+        width: 120px;
+        height: 8px;
+        border-radius: 999px;
+        background: rgba(15, 23, 42, 0.8);
+        overflow: hidden;
+        position: relative;
+      }
+      #gx-hud .gx-bar-fill {
+        height: 100%;
+        background: linear-gradient(90deg, #38bdf8, #6366f1);
+        width: 50%;
+      }
+      #gx-hud .gx-btn {
+        align-self: flex-end;
+      }
+      #gx-vn {
+        border-radius: 16px;
+        border: 1px solid rgba(148, 163, 184, 0.18);
+        background: rgba(15, 23, 42, 0.65);
+        padding: 20px;
+        display: grid;
+        gap: 16px;
+        min-height: 220px;
+      }
+      #gx-name {
+        font-size: 18px;
+        font-weight: 800;
+        letter-spacing: 0.08em;
+        color: #a5b4fc;
+        text-transform: uppercase;
+      }
+      #gx-text {
+        font-size: 17px;
+        line-height: 1.6;
+        color: #e2e8f0;
+        min-height: 96px;
+      }
+      #gx-choices {
+        display: grid;
+        gap: 12px;
+      }
+      #gx-choices button {
+        border-radius: 12px;
+        border: 1px solid rgba(129, 140, 248, 0.45);
+        background: rgba(79, 70, 229, 0.18);
+        color: #e0f2fe;
+        padding: 14px 16px;
+        font-size: 15px;
+        font-weight: 700;
+        text-align: left;
+        cursor: pointer;
+        transition: transform 0.15s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+      }
+      #gx-choices button:hover {
+        transform: translateY(-1px);
+        border-color: rgba(129, 140, 248, 0.7);
+        box-shadow: 0 8px 18px rgba(79, 70, 229, 0.2);
+      }
+      .gx-btn {
+        border-radius: 10px;
+        border: 1px solid rgba(129, 140, 248, 0.4);
+        background: rgba(79, 70, 229, 0.22);
+        color: #e0f2fe;
+        padding: 10px 14px;
+        font-weight: 700;
+        cursor: pointer;
+        transition: background 0.2s ease;
+      }
+      .gx-btn:hover {
+        background: rgba(129, 140, 248, 0.35);
+      }
+      #gx-puzzle {
+        position: absolute;
+        inset: 0;
+        display: none;
+        align-items: center;
+        justify-content: center;
+        padding: 16px;
+        box-sizing: border-box;
+      }
+      #gx-puzzle.gx-active {
+        display: flex;
+      }
+      #gx-puzzle-backdrop {
+        position: absolute;
+        inset: 0;
+        background: rgba(7, 11, 20, 0.78);
+        backdrop-filter: blur(6px);
+      }
+      #gx-puzzle-body {
+        position: relative;
+        z-index: 2;
+        width: min(100%, 720px);
+        border-radius: 18px;
+        padding: 20px;
+        background: rgba(15, 23, 42, 0.95);
+        border: 1px solid rgba(129, 140, 248, 0.3);
+        display: grid;
+        gap: 18px;
+      }
+      #gx-puzzle-header {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+        gap: 12px;
+        align-items: center;
+      }
+      #gx-puzzle-title {
+        margin: 0;
+        font-size: 20px;
+        color: #a5b4fc;
+      }
+      #gx-puzzle-desc {
+        margin: 4px 0 0;
+        font-size: 15px;
+        line-height: 1.5;
+        color: #cbd5f5;
+      }
+      #gx-puzzle-meta {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+      }
+      #gx-puzzle-timer {
+        font-weight: 800;
+        font-size: 16px;
+        min-width: 72px;
+        text-align: right;
+        color: #fcd34d;
+      }
+      #gx-log {
+        position: absolute;
+        inset: 0;
+        display: none;
+        align-items: center;
+        justify-content: center;
+      }
+      #gx-log.gx-active {
+        display: flex;
+      }
+      #gx-log-panel {
+        width: min(100%, 560px);
+        background: rgba(15, 23, 42, 0.94);
+        border-radius: 16px;
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        padding: 20px;
+        box-shadow: 0 24px 60px rgba(15, 23, 42, 0.35);
+        display: grid;
+        gap: 12px;
+        max-height: 80vh;
+      }
+      #gx-log-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+      #gx-log-header h3 {
+        margin: 0;
+        font-size: 18px;
+        color: #a5b4fc;
+      }
+      #gx-log-entries {
+        overflow-y: auto;
+        padding-right: 4px;
+        display: grid;
+        gap: 8px;
+        font-size: 14px;
+        line-height: 1.5;
+      }
+      #gx-log-entries .gx-log-entry {
+        background: rgba(30, 41, 59, 0.65);
+        border-radius: 12px;
+        padding: 10px 12px;
+        border: 1px solid rgba(148, 163, 184, 0.22);
+      }
+      #gx-toast {
+        position: absolute;
+        bottom: 20px;
+        left: 50%;
+        transform: translateX(-50%);
+        display: grid;
+        gap: 8px;
+        z-index: 10;
+      }
+      #gx-toast .gx-toast-item {
+        background: rgba(14, 165, 233, 0.86);
+        padding: 10px 14px;
+        border-radius: 12px;
+        font-size: 14px;
+        font-weight: 600;
+        min-width: 220px;
+        text-align: center;
+        box-shadow: 0 18px 40px rgba(14, 165, 233, 0.28);
+      }
+      #gx-toast .gx-toast-item.warn {
+        background: rgba(249, 115, 22, 0.88);
+        box-shadow: 0 18px 40px rgba(249, 115, 22, 0.28);
+      }
+      #gx-toast .gx-toast-item.error {
+        background: rgba(239, 68, 68, 0.88);
+        box-shadow: 0 18px 40px rgba(239, 68, 68, 0.28);
+      }
+      #gx-toast .gx-toast-item.success {
+        background: rgba(34, 197, 94, 0.88);
+        box-shadow: 0 18px 40px rgba(34, 197, 94, 0.28);
+      }
+      #gx-root .gx-hidden {
+        display: none !important;
+      }
+      #gx-root .pair-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(88px, 1fr));
+        gap: 10px;
+      }
+      #gx-root .pair-card {
+        height: 84px;
+        border-radius: 12px;
+        background: rgba(30, 41, 59, 0.8);
+        border: 1px solid rgba(129, 140, 248, 0.3);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 700;
+        font-size: 22px;
+        cursor: pointer;
+        transition: transform 0.15s ease, background 0.2s ease, border-color 0.2s ease;
+      }
+      #gx-root .pair-card.revealed {
+        background: rgba(129, 140, 248, 0.25);
+        border-color: rgba(165, 180, 252, 0.6);
+        transform: translateY(-2px);
+      }
+      #gx-root .pair-card.matched {
+        background: rgba(52, 211, 153, 0.2);
+        border-color: rgba(52, 211, 153, 0.6);
+        color: #bbf7d0;
+        cursor: default;
+      }
+      #gx-root .slider-row {
+        display: grid;
+        grid-template-columns: repeat(5, minmax(0, 1fr));
+        gap: 12px;
+      }
+      #gx-root .slider-cell {
+        padding: 18px 0;
+        border-radius: 12px;
+        border: 1px solid rgba(94, 234, 212, 0.4);
+        background: rgba(13, 148, 136, 0.16);
+        text-align: center;
+        font-weight: 800;
+        font-size: 20px;
+        cursor: pointer;
+        transition: transform 0.15s ease, border-color 0.2s ease;
+      }
+      #gx-root .slider-cell.selected {
+        border-color: rgba(16, 185, 129, 0.7);
+        transform: translateY(-2px);
+      }
+      #gx-root .rhythm-track {
+        display: grid;
+        grid-template-columns: repeat(5, 1fr);
+        gap: 8px;
+        margin-bottom: 12px;
+      }
+      #gx-root .rhythm-beat {
+        height: 14px;
+        border-radius: 999px;
+        background: rgba(79, 70, 229, 0.3);
+        position: relative;
+        overflow: hidden;
+      }
+      #gx-root .rhythm-beat.active::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: rgba(129, 140, 248, 0.9);
+        animation: gxPulse 0.35s ease;
+      }
+      @keyframes gxPulse {
+        from {
+          opacity: 0.1;
+        }
+        to {
+          opacity: 1;
+        }
+      }
+      #gx-root .circuit-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 12px;
+        justify-items: center;
+      }
+      #gx-root .circuit-node {
+        width: 90px;
+        height: 90px;
+        border-radius: 18px;
+        border: 1px solid rgba(56, 189, 248, 0.4);
+        background: radial-gradient(circle at 50% 40%, rgba(96, 165, 250, 0.32), rgba(30, 64, 175, 0.32));
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-weight: 800;
+        font-size: 24px;
+        cursor: pointer;
+        position: relative;
+        transition: transform 0.16s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+      }
+      #gx-root .circuit-node.selected {
+        border-color: rgba(34, 197, 94, 0.8);
+        box-shadow: 0 0 12px rgba(34, 197, 94, 0.4);
+        transform: translateY(-2px);
+      }
+      #gx-root .circuit-node.start::before {
+        content: 'S';
+        position: absolute;
+        top: 6px;
+        left: 8px;
+        font-size: 12px;
+        color: rgba(241, 245, 249, 0.8);
+      }
+      #gx-root .circuit-node.goal::before {
+        content: 'F';
+        position: absolute;
+        top: 6px;
+        right: 8px;
+        font-size: 12px;
+        color: rgba(241, 245, 249, 0.8);
+      }
+      #gx-root .circuit-controls {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        margin-top: 12px;
+      }
+      @media (max-width: 600px) {
+        #gx-layer {
+          padding: 16px;
+        }
+        #gx-hud {
+          gap: 8px;
+        }
+        #gx-hud .gx-meter {
+          min-width: 120px;
+        }
+        #gx-puzzle-body {
+          padding: 16px;
+        }
+      }
+    `;
+    styleEl = document.createElement("style");
+    styleEl.textContent = css;
+    document.head.appendChild(styleEl);
+  }
+
+  function wireHUD() {
+    const toggleBtn = rootEl.querySelector("#gx-log-toggle");
+    const closeBtn = rootEl.querySelector("#gx-log-close");
+    toggleBtn.addEventListener("click", () => {
+      const panel = rootEl.querySelector("#gx-log");
+      panel.classList.toggle("gx-active");
+    });
+    closeBtn.addEventListener("click", () => {
+      const panel = rootEl.querySelector("#gx-log");
+      panel.classList.remove("gx-active");
+    });
+  }
+
+  function clearTimers() {
+    if (countdownInterval) {
+      clearInterval(countdownInterval);
+      countdownInterval = null;
+    }
+    if (beatTimeout) {
+      clearTimeout(beatTimeout);
+      beatTimeout = null;
+    }
+    if (rhythmAnimation) {
+      cancelAnimationFrame(rhythmAnimation);
+      rhythmAnimation = null;
+    }
+    timeouts.forEach((id) => clearTimeout(id));
+    timeouts.clear();
+  }
+
+  function start() {
+    ensureRoot();
+    initState();
+    if (mountOptions && mountOptions.handoff && mountOptions.handoff.day) {
+      STATE.day = Math.min(mountOptions.handoff.day, STATE.maxDay);
+    }
+    startTimestamp = Date.now();
+    const initialScene = mountOptions && mountOptions.flags && mountOptions.flags.skipIntro ? "act1_intro" : "act1_intro";
+    gotoScene(initialScene);
+    pushLog("게임 세그먼트가 시작되었습니다.");
+  }
+
+  function destroy() {
+    clearTimers();
+    if (rootEl) {
+      rootEl.remove();
+      rootEl = null;
+    }
+    if (styleEl) {
+      styleEl.remove();
+      styleEl = null;
+    }
+    activePuzzle = null;
+    mountOptions = null;
+    STATE = null;
+    startTimestamp = null;
+  }
+
+  function getState() {
+    if (!STATE) return null;
+    return {
+      day: STATE.day,
+      maxDay: STATE.maxDay,
+      sanity: STATE.sanity,
+      suspicion: STATE.suspicion,
+      evidence: Array.from(STATE.evidence),
+      hintUsed: STATE.hintUsed,
+      sceneId: STATE.sceneId,
+      log: STATE.log.slice(),
+      stats: { ...STATE.stats },
+    };
+  }
+
+  function gotoScene(id) {
+    if (!STATE) return;
+    if (id === "ending_check") {
+      evaluateEnding();
+      return;
+    }
+    const scene = SCENES[id];
+    if (!scene) {
+      console.warn("Unknown scene", id);
+      return;
+    }
+    STATE.sceneId = id;
+    const sceneDay = SCENE_DAYS[id];
+    if (sceneDay) {
+      STATE.day = Math.max(STATE.day, sceneDay);
+    }
+    renderScene(scene);
+  }
+
+  function renderScene(scene) {
+    const nameEl = rootEl.querySelector("#gx-name");
+    const textEl = rootEl.querySelector("#gx-text");
+    nameEl.textContent = scene.speaker || "";
+    textEl.textContent = scene.text || "";
+    setChoices(scene.choices || []);
+    updateHUD();
+  }
+
+  function setChoices(list) {
+    const wrap = rootEl.querySelector("#gx-choices");
+    wrap.innerHTML = "";
+    list.forEach((choice) => {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.textContent = choice.text;
+      btn.addEventListener("click", () => {
+        if (choice.effect) {
+          if (typeof choice.effect === "function") {
+            choice.effect();
+          } else {
+            applyEffect(choice.effect);
+          }
+        }
+        if (choice.puzzleKey) {
+          startPuzzle(choice.puzzleKey, choice);
+          return;
+        }
+        if (choice.goto) {
+          gotoScene(choice.goto);
+          return;
+        }
+        updateHUD();
+      });
+      wrap.appendChild(btn);
+    });
+  }
+
+  function applyEffect(effectObj) {
+    if (!effectObj || typeof effectObj !== "object") return;
+    if (effectObj.sanity) {
+      STATE.sanity = Math.max(0, Math.min(5, STATE.sanity + effectObj.sanity));
+      pushLog(`정신력 변화: ${effectObj.sanity > 0 ? "+" : ""}${effectObj.sanity}`);
+      if (STATE.sanity <= 0) {
+        gotoScene("ending_bad");
+        return;
+      }
+    }
+    if (effectObj.addMemo) {
+      addEvidence("memo_note");
+      pushLog("회의실에서 발견한 메모를 인벤토리에 추가했다.");
+    }
+    updateHUD();
+  }
+
+  function startPuzzle(key, meta) {
+    if (!PUZZLES[key]) {
+      console.warn("Unknown puzzle", key);
+      return;
+    }
+    clearTimers();
+    activePuzzle = {
+      key,
+      meta,
+      startedAt: Date.now(),
+      remaining: PUZZLES[key].timeLimit,
+      solvedBeats: 0,
+    };
+    const data = PUZZLES[key];
+    const modal = rootEl.querySelector("#gx-puzzle");
+    modal.classList.add("gx-active");
+    rootEl.querySelector("#gx-puzzle-title").textContent = data.title;
+    rootEl.querySelector("#gx-puzzle-desc").textContent = data.description;
+    rootEl.querySelector("#gx-puzzle-content").innerHTML = "";
+    rootEl.querySelector("#gx-puzzle-hint").onclick = () => {
+      STATE.hintUsed += 1;
+      STATE.stats.hints += 1;
+      showToast(`힌트 사용 (${STATE.hintUsed})`, "warn");
+      pushLog(`힌트 사용: ${data.title}`);
+      showHint(data);
+      updateHUD();
+    };
+    rootEl.querySelector("#gx-puzzle-reset").onclick = () => {
+      showToast("퍼즐을 재설정했습니다.");
+      startPuzzle(key, meta);
+    };
+    startCountdown(data.timeLimit, () => {
+      failPuzzle("시간 초과");
+    });
+
+    switch (key) {
+      case "pairmatch":
+        setupPairMatch(meta);
+        break;
+      case "slider":
+        setupSlider(meta);
+        break;
+      case "rhythm":
+        setupRhythm(meta);
+        break;
+      case "circuit":
+        setupCircuit(meta);
+        break;
+      default:
+        break;
+    }
+  }
+
+  function showHint(data) {
+    showToast(data.hint, "info");
+  }
+
+  function startCountdown(seconds, onExpire) {
+    const timerEl = rootEl.querySelector("#gx-puzzle-timer");
+    const end = Date.now() + seconds * 1000;
+    function tick() {
+      const now = Date.now();
+      const diff = Math.max(0, Math.floor((end - now) / 1000));
+      timerEl.textContent = `${String(diff).padStart(2, "0")}s`;
+      if (diff <= 0) {
+        clearInterval(countdownInterval);
+        countdownInterval = null;
+        onExpire();
+      }
+    }
+    tick();
+    countdownInterval = setInterval(tick, 250);
+  }
+
+  function finishPuzzle(success) {
+    clearTimers();
+    const modal = rootEl.querySelector("#gx-puzzle");
+    modal.classList.remove("gx-active");
+    if (!activePuzzle) return;
+    const data = PUZZLES[activePuzzle.key];
+    if (success) {
+      showToast("퍼즐 성공", "success");
+      addEvidence(data.evidence);
+      if (data.successScene) {
+        gotoScene(data.successScene);
+      }
+    } else {
+      STATE.stats.fails += 1;
+      STATE.sanity = Math.max(0, STATE.sanity - 1);
+      pushLog(`퍼즐 실패: ${data.title}`);
+      showToast("퍼즐 실패", "error");
+      if (STATE.sanity <= 0) {
+        gotoScene("ending_bad");
+      } else if (data.failureScene) {
+        gotoScene(data.failureScene);
+      }
+    }
+    activePuzzle = null;
+    updateHUD();
+  }
+
+  function succeedPuzzle() {
+    finishPuzzle(true);
+  }
+
+  function failPuzzle(reason) {
+    if (reason) {
+      showToast(reason, "warn");
+    }
+    finishPuzzle(false);
+  }
+
+  function addEvidence(key) {
+    if (!STATE.evidence.has(key)) {
+      STATE.evidence.add(key);
+      pushLog(`증거 확보: ${EVIDENCE[key] ? EVIDENCE[key].name : key}`);
+    }
+    recomputeSuspicion();
+    updateHUD();
+  }
+
+  function recomputeSuspicion() {
+    let s = 0;
+    for (const k of STATE.evidence) {
+      const e = EVIDENCE[k];
+      if (!e) continue;
+      s += (e.weight * e.reliability) * 100 / 3;
+    }
+    const hintPenalty = Math.min(STATE.hintUsed * 3, 20);
+    STATE.suspicion = Math.max(0, Math.min(100, Math.round(s - hintPenalty)));
+  }
+
+  function updateHUD() {
+    if (!rootEl || !STATE) return;
+    const dayEl = rootEl.querySelector("#gx-day");
+    const sanityEl = rootEl.querySelector("#gx-sanity");
+    const sanityBar = rootEl.querySelector("#gx-sanity-bar");
+    const suspEl = rootEl.querySelector("#gx-suspicion");
+    const suspBar = rootEl.querySelector("#gx-suspicion-bar");
+    const evidenceEl = rootEl.querySelector("#gx-evidence-count");
+
+    dayEl.textContent = `${STATE.day} / ${STATE.maxDay}`;
+    sanityEl.textContent = `${STATE.sanity}`;
+    sanityBar.style.width = `${(STATE.sanity / 5) * 100}%`;
+    suspEl.textContent = `${STATE.suspicion}`;
+    suspBar.style.width = `${STATE.suspicion}%`;
+    evidenceEl.textContent = `${STATE.evidence.size}`;
+
+    const logEl = rootEl.querySelector("#gx-log-entries");
+    logEl.innerHTML = STATE.log
+      .map((entry) => `<div class="gx-log-entry">${entry}</div>`)
+      .join("");
+  }
+
+  function pushLog(textHtml) {
+    if (!STATE) return;
+    STATE.log.push(textHtml);
+    if (STATE.log.length > 60) {
+      STATE.log.shift();
+    }
+    updateHUD();
+  }
+
+  function showToast(msg, type = "info") {
+    const toastWrap = rootEl.querySelector("#gx-toast");
+    const item = document.createElement("div");
+    item.className = `gx-toast-item ${type}`;
+    item.textContent = msg;
+    toastWrap.appendChild(item);
+    const id = setTimeout(() => {
+      item.remove();
+      timeouts.delete(id);
+    }, 2200);
+    timeouts.add(id);
+  }
+
+  function evaluateEnding() {
+    if (STATE.sanity <= 0) {
+      gotoScene("ending_bad");
+      return;
+    }
+    recomputeSuspicion();
+    if (STATE.evidence.has("label_scan") && STATE.day < 2) {
+      STATE.day = 2;
+    }
+    if (STATE.evidence.has("gel_capsule") && STATE.day < 3) {
+      STATE.day = 3;
+    }
+    if (STATE.evidence.has("voice_loop") && STATE.day < 4) {
+      STATE.day = 4;
+    }
+    if (STATE.evidence.has("memo_note") && STATE.day < 4) {
+      STATE.day = 4;
+    }
+
+    if (STATE.sanity <= 0) {
+      gotoScene("ending_bad");
+      return;
+    }
+
+    const evidenceScore = STATE.evidence.size;
+    const susp = STATE.suspicion;
+    if (susp >= 70 && evidenceScore >= 4) {
+      gotoScene("ending_good");
+    } else if (susp >= 40 && evidenceScore >= 2) {
+      gotoScene("ending_neutral");
+    } else {
+      gotoScene("ending_bad");
+    }
+  }
+
+  function finishGame(endingKey) {
+    clearTimers();
+    if (!STATE) return;
+    if (startTimestamp) {
+      STATE.stats.timeSpent = Date.now() - startTimestamp;
+    }
+    const result = {
+      ending: endingKey,
+      stats: {
+        fails: STATE.stats.fails,
+        hints: STATE.stats.hints,
+        timeSpent: STATE.stats.timeSpent,
+        evidence: Array.from(STATE.evidence),
+      },
+    };
+    pushLog(`엔딩 도달: ${endingKey}`);
+    if (mountOptions && mountOptions.onEnd) {
+      mountOptions.onEnd(result);
+    }
+  }
+
+  function setupPairMatch() {
+    const pairs = [
+      { code: "A.", meaning: "산도 조절" },
+      { code: "B..", meaning: "혈류 촉진" },
+      { code: "C", meaning: "해독 보조" },
+      { code: "D...", meaning: "각성" },
+      { code: "E.", meaning: "냉감 유지" },
+      { code: "F", meaning: "광택 첨가" },
+    ];
+    const cards = [];
+    pairs.forEach((p, idx) => {
+      cards.push({ id: `c${idx}-a`, key: idx, label: p.code });
+      cards.push({ id: `c${idx}-b`, key: idx, label: p.meaning });
+    });
+    const ordered = shuffle(cards);
+    const wrap = document.createElement("div");
+    wrap.className = "pair-grid";
+    const state = { opened: [], matched: new Set() };
+
+    ordered.forEach((card) => {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "pair-card";
+      btn.dataset.key = card.key;
+      btn.textContent = "?";
+      btn.addEventListener("click", () => {
+        if (state.matched.has(card.id) || btn.classList.contains("matched")) return;
+        if (state.opened.some((o) => o.id === card.id)) return;
+        reveal(btn, card.label);
+        state.opened.push({ id: card.id, key: card.key, element: btn, label: card.label });
+        if (state.opened.length === 2) {
+          const [a, b] = state.opened;
+          if (a.key === b.key && a.id !== b.id) {
+            a.element.classList.add("matched");
+            b.element.classList.add("matched");
+            state.matched.add(a.id);
+            state.matched.add(b.id);
+            state.opened = [];
+            if (state.matched.size === ordered.length) {
+              succeedPuzzle();
+            }
+          } else {
+            const id = setTimeout(() => {
+              hide(a.element);
+              hide(b.element);
+              state.opened = [];
+              timeouts.delete(id);
+            }, 700);
+            timeouts.add(id);
+          }
+        }
+      });
+      wrap.appendChild(btn);
+    });
+
+    rootEl.querySelector("#gx-puzzle-content").appendChild(wrap);
+
+    function reveal(el, label) {
+      el.classList.add("revealed");
+      el.textContent = label;
+    }
+
+    function hide(el) {
+      el.classList.remove("revealed");
+      el.textContent = "?";
+    }
+  }
+
+  function setupSlider() {
+    const target = ["P", "U", "R", "E", "E"];
+    let current = shuffle(target.slice()).slice(0, target.length);
+    if (arraysEqual(current, target)) {
+      current = shuffle(target.slice());
+    }
+    const wrap = document.createElement("div");
+    wrap.className = "slider-row";
+    let selectedIndex = null;
+
+    current.forEach((value, index) => {
+      const cell = document.createElement("button");
+      cell.type = "button";
+      cell.className = "slider-cell";
+      cell.textContent = value;
+      cell.addEventListener("click", () => {
+        if (selectedIndex === null) {
+          selectedIndex = index;
+          cell.classList.add("selected");
+        } else if (selectedIndex === index) {
+          cell.classList.remove("selected");
+          selectedIndex = null;
+        } else {
+          const other = wrap.children[selectedIndex];
+          const tmp = current[selectedIndex];
+          current[selectedIndex] = current[index];
+          current[index] = tmp;
+          other.textContent = current[selectedIndex];
+          cell.textContent = current[index];
+          other.classList.remove("selected");
+          selectedIndex = null;
+          if (arraysEqual(current, target)) {
+            succeedPuzzle();
+          }
+        }
+      });
+      wrap.appendChild(cell);
+    });
+
+    rootEl.querySelector("#gx-puzzle-content").appendChild(wrap);
+  }
+
+  function setupRhythm() {
+    const schedule = [0, 1000, 2000, 3300, 4700];
+    const tolerance = 120;
+    const windowMs = 320;
+    const track = document.createElement("div");
+    track.className = "rhythm-track";
+    const beatsEls = schedule.map(() => {
+      const div = document.createElement("div");
+      div.className = "rhythm-beat";
+      track.appendChild(div);
+      return div;
+    });
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "gx-btn";
+    button.textContent = "탭";
+    const info = document.createElement("p");
+    info.textContent = "표시가 켜질 때 버튼을 눌러 파형을 동기화하세요.";
+    info.style.margin = "0";
+    info.style.opacity = "0.8";
+    info.style.fontSize = "14px";
+
+    const contentEl = rootEl.querySelector("#gx-puzzle-content");
+    contentEl.appendChild(info);
+    contentEl.appendChild(track);
+    contentEl.appendChild(button);
+
+    let currentBeat = -1;
+    let expected = null;
+    let started = false;
+
+    button.addEventListener("click", () => {
+      if (!started || expected === null) return;
+      const diff = Math.abs(Date.now() - expected);
+      if (diff <= tolerance) {
+        beatsEls[currentBeat].classList.remove("active");
+        if (beatTimeout) {
+          clearTimeout(beatTimeout);
+          beatTimeout = null;
+        }
+        expected = null;
+        activePuzzle.solvedBeats += 1;
+        if (activePuzzle.solvedBeats === schedule.length) {
+          succeedPuzzle();
+        }
+      } else {
+        failPuzzle("박자를 놓쳤습니다");
+      }
+    });
+
+    const startId = setTimeout(() => {
+      started = true;
+      triggerBeat(0);
+      timeouts.delete(startId);
+    }, 600);
+    timeouts.add(startId);
+
+    function triggerBeat(index) {
+      if (!activePuzzle || activePuzzle.key !== "rhythm") return;
+      currentBeat = index;
+      beatsEls.forEach((el, idx) => {
+        if (idx === index) {
+          el.classList.add("active");
+        } else {
+          el.classList.remove("active");
+        }
+      });
+      expected = Date.now();
+      if (beatTimeout) {
+        clearTimeout(beatTimeout);
+        beatTimeout = null;
+      }
+      beatTimeout = setTimeout(() => {
+        beatsEls[index].classList.remove("active");
+        beatTimeout = null;
+        if (expected !== null) {
+          failPuzzle("박자를 놓쳤습니다");
+        }
+      }, windowMs);
+      if (index + 1 < schedule.length) {
+        const delay = Math.max(200, schedule[index + 1] - schedule[index]);
+        const id = setTimeout(() => {
+          triggerBeat(index + 1);
+          timeouts.delete(id);
+        }, delay);
+        timeouts.add(id);
+      }
+    }
+  }
+
+
+  function setupCircuit() {
+    const nodes = [
+      { id: "A", className: "start" },
+      { id: "B" },
+      { id: "C" },
+      { id: "D" },
+      { id: "E" },
+      { id: "F", className: "goal" },
+    ];
+    const adjacency = {
+      A: ["B", "C"],
+      B: ["A", "D"],
+      C: ["A", "D", "E"],
+      D: ["B", "C", "F"],
+      E: ["C", "F"],
+      F: ["D", "E"],
+    };
+    const solution = ["A", "C", "E", "F"];
+    const wrap = document.createElement("div");
+    wrap.className = "circuit-grid";
+    const selected = [];
+
+    nodes.forEach((node) => {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = `circuit-node ${node.className || ""}`.trim();
+      btn.textContent = node.id;
+      btn.addEventListener("click", () => {
+        if (!selected.length) {
+          if (node.id !== "A") {
+            showToast("A에서 시작해야 합니다.", "warn");
+            return;
+          }
+          selected.push(node.id);
+          btn.classList.add("selected");
+          return;
+        }
+        const last = selected[selected.length - 1];
+        if (!adjacency[last].includes(node.id)) {
+          showToast("연결되지 않은 노드입니다.", "warn");
+          resetSelection();
+          return;
+        }
+        if (selected.includes(node.id)) {
+          showToast("이미 선택한 노드입니다.", "warn");
+          resetSelection();
+          return;
+        }
+        selected.push(node.id);
+        btn.classList.add("selected");
+      });
+      wrap.appendChild(btn);
+    });
+
+    const controls = document.createElement("div");
+    controls.className = "circuit-controls";
+    const submitBtn = document.createElement("button");
+    submitBtn.type = "button";
+    submitBtn.className = "gx-btn";
+    submitBtn.textContent = "전류 흐르게";
+    submitBtn.addEventListener("click", () => {
+      if (arraysEqual(selected, solution)) {
+        succeedPuzzle();
+      } else {
+        failPuzzle("회로가 어긋났습니다");
+      }
+    });
+    const resetBtn = document.createElement("button");
+    resetBtn.type = "button";
+    resetBtn.className = "gx-btn";
+    resetBtn.textContent = "리셋";
+    resetBtn.addEventListener("click", () => {
+      resetSelection();
+    });
+    controls.appendChild(resetBtn);
+    controls.appendChild(submitBtn);
+
+    const content = rootEl.querySelector("#gx-puzzle-content");
+    content.appendChild(wrap);
+    content.appendChild(controls);
+
+    function resetSelection() {
+      selected.length = 0;
+      wrap.querySelectorAll(".circuit-node").forEach((el) => el.classList.remove("selected"));
+    }
+  }
+
+  function arraysEqual(a, b) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i += 1) {
+      if (a[i] !== b[i]) return false;
+    }
+    return true;
+  }
+
+  function shuffle(arr) {
+    const copy = arr.slice();
+    for (let i = copy.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(Math.random() * (i + 1));
+      const tmp = copy[i];
+      copy[i] = copy[j];
+      copy[j] = tmp;
+    }
+    return copy;
+  }
+
+  global[NAMESPACE] = {
+    mount,
+    start,
+    destroy,
+    getState,
+    gotoScene,
+    renderScene,
+    setChoices,
+    applyEffect,
+    startPuzzle,
+    addEvidence,
+    recomputeSuspicion,
+    updateHUD,
+    pushLog,
+    showToast,
+  };
+})(window);
+
+    </script>
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const root = document.getElementById('game-root');
+        if (!root) return;
+        window.GreenJuiceGame.mount({
+          container: root,
+          flags: { skipIntro: true },
+          onEnd(result) {
+            console.log('Game Ended', result);
+          },
+        });
+        window.GreenJuiceGame.start();
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a self-contained `green-juice-game.html` implementing the post-intro visual novel and puzzle gameplay
- define the GreenJuiceGame namespace with lifecycle APIs, state handling, HUD/log UI, and four puzzle implementations
- include styling scoped to `#gx-root`, scene scripting, suspicion calculation, and ending resolution with result callback

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e2228f05a483208b7a986c546aafd9