### PR TITLE
Add label matching mini-game to label puzzle

### DIFF
--- a/green-juice-game.html
+++ b/green-juice-game.html
@@ -28,9 +28,14 @@
   .label-content .icons { font-size:28px; letter-spacing:10px }
   .label-content .letters { font-size:20px; letter-spacing:6px }
   .label-prompt { margin-top:16px; display:grid; gap:12px }
-  .label-input-row { display:flex; flex-wrap:wrap; gap:8px }
-  #labelInput { flex:1; min-width:140px; padding:10px 12px; border-radius:10px; border:1px solid #2a2a58; background:#0e0e26; color:#f8fafc; font:700 18px/1 ui-monospace, Menlo, monospace; text-transform:uppercase; letter-spacing:3px }
-  #labelInput:focus { outline:2px solid rgba(99,102,241,0.7); outline-offset:2px }
+  .label-board { display:grid; grid-template-columns:repeat(4, minmax(64px, 1fr)); gap:10px }
+  .label-controls { display:flex; justify-content:flex-end }
+  .label-card { position:relative; padding:16px 10px; border:1px solid #2a2a58; border-radius:12px; background:rgba(15,15,40,0.95); color:#e2e8f0; font:700 22px/1.1 ui-monospace, Menlo, monospace; letter-spacing:4px; transition:background .2s ease, transform .2s ease; cursor:pointer }
+  .label-card.is-letter { letter-spacing:3px; font-size:18px }
+  .label-card.is-icon { font-size:28px; letter-spacing:8px }
+  .label-card.revealed { background:rgba(88,91,229,0.22); border-color:rgba(129,140,248,0.45); color:#c7d2fe }
+  .label-card.matched { background:rgba(34,197,94,0.2); border-color:rgba(134,239,172,0.55); color:#bbf7d0; cursor:default }
+  .label-card:disabled { cursor:default; opacity:.88 }
   .ghost-button { border-color:rgba(99,102,241,0.55); background:rgba(17,17,40,0.85); color:#dbeafe }
   .ghost-button:hover { filter:brightness(1.08) }
   .keypad { display:grid; grid-template-columns: repeat(3,1fr); gap:8px; margin-top:8px }
@@ -61,19 +66,18 @@
 
     <!-- 퍼즐1: 라벨 기억 -->
     <div id="puzzleLabel" class="hidden">
-      <div class="row"><b>라벨 해독</b><span class="note">3초 동안 라벨을 기억한 뒤 정답을 입력하세요.</span></div>
+      <div class="row"><b>라벨 해독</b><span class="note">3초 동안 카드 위치를 기억한 뒤 아이콘과 문자를 짝지으세요.</span></div>
       <div id="labelFlash" class="label-flash">
         <div id="labelCountdown" class="label-countdown">3</div>
         <div id="labelContent" class="label-content"></div>
       </div>
       <div id="labelPrompt" class="label-prompt hidden">
-        <div class="note">기억한 알파벳 네 글자를 순서대로 입력하세요.</div>
-        <div class="label-input-row">
-          <input id="labelInput" maxlength="4" autocomplete="off" spellcheck="false" />
-          <button id="labelSubmit">확인</button>
+        <div class="note">카드를 기억한 뒤, 아이콘과 알파벳을 짝지어 모두 맞춰보세요. 공개 시간은 3초뿐입니다.</div>
+        <div id="labelBoard" class="label-board"></div>
+        <div class="label-controls">
           <button id="labelReplay" class="ghost-button">다시 보기</button>
         </div>
-        <div class="note">힌트: 🌿=C, 💧=H, 🧪=L, 🧊=O</div>
+        <div class="note">힌트: 🌿↔C, 💧↔H, 🧪↔L, 🧊↔O</div>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- replace the label typing puzzle with an icon-letter card matching mini-game that appears after a three-second reveal
- add styling and layout for the new card board and replay control in both the standalone page and embedded template
- update label puzzle logic to manage card states, replay peeks, and completion handling while keeping other scenes intact

## Testing
- Manual testing: opened `green-juice-game.html` in a browser via `python3 -m http.server 8000` and played through the label puzzle


------
https://chatgpt.com/codex/tasks/task_e_68e274c6796c832099e7bf87a953459a