### PR TITLE
Auto-scroll to label puzzle and hide ready button

### DIFF
--- a/green-juice-game.js
+++ b/green-juice-game.js
@@ -310,17 +310,19 @@ button:hover { filter:brightness(1.1) }
         {
           text: "준비됐다",
           onClick: (event) => {
+            const target = event && event.currentTarget;
             if (STATE.labelStarted) {
-              if (event && event.currentTarget) {
-                event.currentTarget.disabled = true;
+              if (target) {
+                target.disabled = true;
               }
               return;
             }
             STATE.labelStarted = true;
-            if (event && event.currentTarget) {
-              event.currentTarget.disabled = true;
+            if (target) {
+              target.disabled = true;
+              target.classList.add("hidden");
             }
-            startLabelPuzzle();
+            startLabelPuzzle({ scrollIntoView: true });
           },
         },
       ]);
@@ -352,7 +354,7 @@ button:hover { filter:brightness(1.1) }
     }
   }
 
-  function startLabelPuzzle() {
+  function startLabelPuzzle({ scrollIntoView = false } = {}) {
     const {
       puzzleLabel,
       labelFlash,
@@ -544,6 +546,13 @@ button:hover { filter:brightness(1.1) }
     }
 
     puzzleLabel.classList.remove("hidden");
+    if (scrollIntoView && typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(() => {
+        if (puzzleLabel && typeof puzzleLabel.scrollIntoView === "function") {
+          puzzleLabel.scrollIntoView({ behavior: "smooth", block: "start" });
+        }
+      });
+    }
     if (labelReplay) {
       labelReplay.onclick = () => {
         if (STATE.sanity <= 1) {


### PR DESCRIPTION
## Summary
- hide the "준비됐다" button after the first click to prevent repeated use
- automatically scroll the view to the label puzzle cards when the puzzle starts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2842a5404832095ffbd2833ff8e7b