### PR TITLE
Make final encounter fullscreen and reuse hero art

### DIFF
--- a/green-juice-game.js
+++ b/green-juice-game.js
@@ -93,7 +93,7 @@
 </div>`;
 
   const STYLES = `
-#gx-lite { max-width: 760px; margin: 0 auto; padding: 24px 28px 36px; min-height: 520px; font-family: ui-sans-serif, system-ui, "Noto Sans KR", Arial; color:#eee; background:#121225; border:1px solid #2a2a58; border-radius:16px }
+#gx-lite { max-width: 760px; margin: 0 auto; padding: 24px 28px 36px; min-height: 520px; box-sizing:border-box; font-family: ui-sans-serif, system-ui, "Noto Sans KR", Arial; color:#eee; background:#121225; border:1px solid #2a2a58; border-radius:16px }
 .hud { display:flex; gap:8px; flex-wrap:wrap; margin-bottom:12px; font-size:14px }
 .pill { padding:6px 10px; border:1px solid #2a2a58; border-radius:999px; background:#191936 }
 .bar { height:6px; border:1px solid #2a2a58; background:#101028; border-radius:999px; overflow:hidden }
@@ -136,13 +136,23 @@ button:hover { filter:brightness(1.1) }
 .modal-actions { display:flex; justify-content:flex-end; gap:8px }
 .hidden { display:none !important }
 .toast { position:fixed; right:16px; bottom:16px; background:#22224a; color:#eee; padding:10px 12px; border:1px solid #2a2a58; border-radius:8px }
+.gjl-no-scroll { overflow:hidden !important }
+#gx-lite.arcade-fullscreen { position:fixed; inset:0; width:100vw; height:100vh; margin:0; max-width:none; border-radius:0; padding:clamp(20px,4vh,48px) clamp(20px,4vw,56px); background:radial-gradient(1200px 600px at 50% 0%,#030712,#01030a); display:grid; align-content:center; justify-items:center; gap:clamp(18px,4vh,32px); box-sizing:border-box; z-index:120; overflow:hidden }
+#gx-lite.arcade-fullscreen .final-enc { width:min(960px, 100%); height:min(720px, 100%); margin:0; padding:clamp(18px,3vh,32px); display:grid; align-content:center; justify-items:center }
+#gx-lite.arcade-fullscreen .final-message { font-size:clamp(15px, 1.6vw, 18px); max-width:min(580px, 80%) }
+#gx-lite.arcade-fullscreen .final-transition { height:clamp(260px, 32vh, 360px) }
+#gx-lite.arcade-fullscreen .final-game { width:100%; max-width:min(840px, 100%); display:grid; gap:clamp(14px, 2vh, 24px); align-self:stretch; justify-self:center }
+#gx-lite.arcade-fullscreen .arcade-stage { height:clamp(360px, 58vh, 640px) }
+#gx-lite.arcade-fullscreen .arcade-hud { font-size:clamp(14px, 1.6vw, 18px) }
+#gx-lite.arcade-fullscreen .arcade-instructions { font-size:clamp(13px, 1.5vw, 16px) }
+#gx-lite.arcade-fullscreen .arcade-overlay { font-size:clamp(14px, 1.6vw, 18px) }
 .final-enc { position:relative; margin-top:20px; padding:22px; border:1px solid #2a2a58; border-radius:16px; background:radial-gradient(circle at top,#020617 0%,#020b1b 55%,#010409 100%); overflow:hidden; min-height:320px; display:grid; place-items:center; gap:16px; transition:background .6s ease }
 .final-message { font-size:15px; line-height:1.6; color:rgba(226,232,240,0.92); text-align:center; max-width:420px }
 .final-enc.is-flicker { animation:finalFlicker .16s steps(2,end) infinite; background:radial-gradient(circle at top,#000,#00140a 60%,#000) }
 .final-transition { position:relative; width:100%; height:260px; display:flex; align-items:center; justify-content:center; transition:transform .8s ease, opacity .8s ease }
 .transition-face { position:absolute; top:50%; left:50%; width:220px; height:240px; transform:translate(-50%,-50%) scale(1.08); border-radius:44% 46% 40% 42%; opacity:0; transition:opacity .8s ease, transform .9s ease; box-shadow:0 0 36px rgba(34,197,94,0.28) }
 .transition-face.human { background:radial-gradient(circle at 40% 30%,#f8fafc 0%,#cbd5f5 60%,#1f2937 100%); box-shadow:0 0 32px rgba(148,163,184,0.38) }
-.transition-face.reptile { background:radial-gradient(circle at 45% 35%,#22c55e 0%,#047857 55%,#052e16 100%); filter:contrast(1.15) saturate(1.25); box-shadow:0 0 40px rgba(34,197,94,0.45) }
+.transition-face.reptile { background:linear-gradient(180deg,rgba(8,22,17,0.75),rgba(1,10,8,0.95)),url('./hero-face.svg'); background-size:cover; background-position:center 30%; background-repeat:no-repeat; filter:contrast(1.15) saturate(1.25); box-shadow:0 0 40px rgba(34,197,94,0.45) }
 .transition-glitch { position:absolute; inset:0; background:repeating-linear-gradient(180deg,rgba(34,197,94,0.16) 0,rgba(34,197,94,0.16) 2px,transparent 2px,transparent 4px); mix-blend-mode:screen; opacity:0; transition:opacity .5s ease }
 .final-enc.show-human #faceHuman { opacity:1; transform:translate(-50%,-50%) scale(1) }
 .final-enc.show-reptile #faceReptile { opacity:1; transform:translate(-50%,-50%) scale(1.08) }
@@ -152,8 +162,8 @@ button:hover { filter:brightness(1.1) }
 .final-game { position:relative; display:grid; gap:14px; width:100%; opacity:0; transform:translateY(14px); transition:opacity .6s ease, transform .6s ease }
 .final-enc.show-game .final-game { opacity:1; transform:translateY(0) }
 .arcade-hud { display:flex; justify-content:space-between; gap:12px; font-weight:600; font-size:14px }
-.arcade-stage { position:relative; height:240px; border:1px solid #2f365f; border-radius:18px; background:linear-gradient(180deg,#020617,#0f172a 65%,#020617); overflow:hidden; box-shadow:inset 0 0 28px rgba(5,10,32,0.65) }
-.arcade-stage .enemy { position:absolute; top:18px; left:50%; width:120px; height:120px; transform:translateX(-50%); border-radius:48% 52% 40% 40%; background:radial-gradient(circle at 40% 40%,#22c55e 0%,#15803d 45%,#052e16 100%); box-shadow:0 0 28px rgba(34,197,94,0.45); transition:filter .2s ease, transform .2s ease }
+.arcade-stage { position:relative; height:clamp(280px, 60vh, 520px); border:1px solid #2f365f; border-radius:18px; background:linear-gradient(180deg,#020617,#0f172a 65%,#020617); overflow:hidden; box-shadow:inset 0 0 28px rgba(5,10,32,0.65) }
+.arcade-stage .enemy { position:absolute; top:18px; left:50%; width:clamp(140px, 22vh, 260px); height:clamp(140px, 22vh, 260px); transform:translateX(-50%); border-radius:48% 52% 40% 40%; background:linear-gradient(180deg,rgba(5,15,12,0.65),rgba(2,6,12,0.95)),url('./hero-face.svg'); background-size:cover; background-position:center 30%; background-repeat:no-repeat; box-shadow:0 0 28px rgba(34,197,94,0.45); transition:filter .2s ease, transform .2s ease }
 .arcade-stage .enemy.hit { animation:enemyHit .3s ease }
 .arcade-stage .player { position:absolute; bottom:18px; left:50%; width:80px; height:44px; transform:translateX(-50%); border-radius:24px 24px 14px 14px; background:linear-gradient(180deg,#fef3c7 0%,#facc15 75%,#b45309 100%); box-shadow:0 0 0 2px rgba(249,250,229,0.3); transition:transform .2s ease }
 .arcade-stage .player.hit { animation:playerHit .35s ease }
@@ -341,6 +351,22 @@ button:hover { filter:brightness(1.1) }
       toast.classList.add("hidden");
       STATE.toastTimer = null;
     }, ms);
+  }
+
+  function toggleArcadeFullscreen(active) {
+    if (!STATE) return;
+    const root = STATE.root;
+    const docEl = document.documentElement;
+    const body = document.body;
+    if (root) {
+      root.classList.toggle("arcade-fullscreen", !!active);
+    }
+    if (docEl) {
+      docEl.classList.toggle("gjl-no-scroll", !!active);
+    }
+    if (body) {
+      body.classList.toggle("gjl-no-scroll", !!active);
+    }
   }
 
   function updateHUD() {
@@ -780,6 +806,7 @@ button:hover { filter:brightness(1.1) }
     const { refs } = STATE || {};
     if (!refs) return;
     stopFinalArcade();
+    toggleArcadeFullscreen(false);
     clearArcadeOverlay();
     const { finalEncounter, finalGame, finalVictory, hud, vn, finalArcadeOverlay } = refs;
     if (finalArcadeOverlay) finalArcadeOverlay.classList.add("hidden");
@@ -812,6 +839,8 @@ button:hover { filter:brightness(1.1) }
       endingGood();
       return;
     }
+
+    toggleArcadeFullscreen(true);
 
     finalEncounter.classList.remove("hidden", "victory", "show-human", "show-reptile", "shrink-face", "show-game");
     finalEncounter.classList.add("is-flicker");
@@ -1174,6 +1203,8 @@ button:hover { filter:brightness(1.1) }
       STATE.onEnd = typeof onEnd === "function" ? onEnd : null;
       STATE.root = nodes.root;
       STATE.toast = nodes.toast;
+
+      toggleArcadeFullscreen(false);
 
       STATE.refs = {
         sanVal: nodes.root.querySelector("#sanVal"),

--- a/hero-face.svg
+++ b/hero-face.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 360">
+  <defs>
+    <linearGradient id="g1" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#0b1320" />
+    </linearGradient>
+    <pattern id="scales" width="10" height="10" patternUnits="userSpaceOnUse">
+      <path d="M0 10 Q5 0 10 10" fill="none" stroke="#3fa66b" stroke-width="1" />
+    </pattern>
+    <clipPath id="half-right">
+      <rect x="0" y="-160" width="160" height="320" />
+    </clipPath>
+    <clipPath id="half-left">
+      <rect x="-160" y="-160" width="160" height="320" />
+    </clipPath>
+  </defs>
+  <rect width="600" height="360" fill="url(#g1)" rx="16" />
+  <g transform="translate(300 180)">
+    <ellipse cx="0" cy="0" rx="120" ry="140" fill="#e5e7eb" stroke="#0c1220" stroke-width="4" />
+    <line x1="0" y1="-140" x2="0" y2="140" stroke="#0c1220" stroke-width="4" />
+    <g clip-path="url(#half-right)">
+      <ellipse cx="0" cy="0" rx="120" ry="140" fill="#0f3b33" />
+      <ellipse cx="50" cy="-10" rx="26" ry="18" fill="#d6b410" stroke="#0b1220" stroke-width="4" />
+      <circle cx="58" cy="-10" r="6" fill="#0b1220" />
+      <rect x="-120" y="-140" width="240" height="280" fill="url(#scales)" opacity="0.4" />
+    </g>
+    <g clip-path="url(#half-left)">
+      <ellipse cx="0" cy="0" rx="120" ry="140" fill="#cbd5e1" />
+      <ellipse cx="-50" cy="-12" rx="22" ry="14" fill="#1e293b" />
+      <circle cx="-52" cy="-12" r="5" fill="#93c5fd" />
+    </g>
+    <path d="M-30 50 Q0 70 30 50" fill="none" stroke="#0b1220" stroke-width="7" stroke-linecap="round" />
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -16,131 +16,42 @@
         color: #e2e8f0;
       }
 
-      .page-wrap {
+      body {
         display: flex;
-        align-items: center;
+        align-items: stretch;
         justify-content: center;
-        min-height: 100vh;
-        padding: 24px;
-        box-sizing: border-box;
-      }
-
-      .game-shell {
-        width: min(100%, 960px);
-        background: rgba(15, 23, 42, 0.92);
-        border: 1px solid rgba(148, 163, 184, 0.22);
-        border-radius: 22px;
-        padding: 32px 28px;
-        box-shadow: 0 28px 80px rgba(15, 23, 42, 0.55);
-      }
-
-      .intro-wrap {
-        text-align: center;
-      }
-
-      .intro-wrap h1 {
-        margin: 0 0 18px;
-        font-size: clamp(1.6rem, 2.2vw + 1rem, 2.6rem);
-        font-weight: 600;
-        color: #f8fafc;
-        letter-spacing: -0.02em;
-      }
-
-      .intro-meta {
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: center;
-        gap: 12px 20px;
-        margin-bottom: 32px;
-        font-size: 0.95rem;
-        color: rgba(148, 163, 184, 0.9);
-      }
-
-      .intro-meta span {
-        display: inline-flex;
-        align-items: center;
-        gap: 6px;
-        padding: 6px 12px;
-        border-radius: 999px;
-        border: 1px solid rgba(148, 163, 184, 0.35);
-        background: rgba(15, 23, 42, 0.55);
-      }
-
-      .primary-button {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        gap: 10px;
-        padding: 14px 28px;
-        border-radius: 999px;
-        border: none;
-        font-size: 1.05rem;
-        font-weight: 600;
-        background: linear-gradient(135deg, #38bdf8, #6366f1);
-        color: #0b1120;
-        cursor: pointer;
-        box-shadow: 0 12px 30px rgba(56, 189, 248, 0.35);
-        transition: transform 120ms ease, box-shadow 120ms ease;
-      }
-
-      .primary-button:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 16px 36px rgba(56, 189, 248, 0.45);
-      }
-
-      .primary-button:active {
-        transform: translateY(0);
-        box-shadow: 0 8px 20px rgba(56, 189, 248, 0.32);
-      }
-
-      .primary-button svg {
-        width: 20px;
-        height: 20px;
       }
 
       .game-section {
-        margin-top: 32px;
+        flex: 1;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: min(5vh, 48px) min(4vw, 48px);
+        box-sizing: border-box;
       }
 
       .game-section.is-hidden {
         display: none;
       }
 
-      @media (max-width: 640px) {
-        .game-shell {
-          padding: 24px 20px;
-        }
-
-        .intro-meta {
-          flex-direction: column;
-          gap: 10px;
-        }
+      .game-root {
+        width: min(100%, 960px);
+        display: flex;
+        justify-content: center;
       }
     </style>
   </head>
   <body>
-    <div class="page-wrap">
-      <div class="game-shell">
-        <div class="intro-wrap" id="intro-section">
-          <h1>잠입자 의심 신고서</h1>
-          <div class="intro-meta">
-            <span>07:45 — 탕비실 문이 열리기 전</span>
-            <span>증거 수집 단계 4회</span>
-            <span>정신력 관리 필수</span>
-          </div>
-        </div>
-        <div class="game-section is-hidden" id="game-section">
-          <div id="game-root"></div>
-        </div>
-      </div>
+    <div class="game-section is-hidden" id="game-section">
+      <div id="game-root" class="game-root"></div>
     </div>
     <div id="intro-root"></div>
     <script src="./green-juice-game.js"></script>
     <script>
       (function () {
         function init() {
-          const startButton = document.getElementById("start-commute");
-          const introSection = document.getElementById("intro-section");
           const gameSection = document.getElementById("game-section");
           const root = document.getElementById("game-root");
           if (!gameSection || !root || !window.GreenJuiceLite) {
@@ -152,9 +63,6 @@
           function startExperience() {
             if (started) return;
             started = true;
-            if (introSection) {
-              introSection.classList.add("is-hidden");
-            }
             gameSection.classList.remove("is-hidden");
 
             window.GreenJuiceLite.mount({
@@ -166,11 +74,7 @@
             window.GreenJuiceLite.start();
           }
 
-          if (startButton) {
-            startButton.addEventListener("click", startExperience);
-          }
-
-          window.addEventListener("greenjuice:introComplete", startExperience, { once: false });
+          window.addEventListener("greenjuice:introComplete", startExperience, { once: true });
         }
 
         if (document.readyState === "loading") {
@@ -188,59 +92,14 @@
 
       function HeroIllust() {
         return (
-          <svg
-            viewBox="0 0 600 360"
-            style={{
-              width: "min(92vw, 820px)",
-              maxWidth: 900,
-              height: "auto",
-              borderRadius: 16,
-              border: "1px solid rgba(255,255,255,0.12)",
-              background: "linear-gradient(180deg,#070a13,#0a0f1f)",
-            }}
-          >
-            <defs>
-              <linearGradient id="g1" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="0%" stopColor="#0f172a" />
-                <stop offset="100%" stopColor="#0b1320" />
-              </linearGradient>
-              <pattern id="scales" width="10" height="10" patternUnits="userSpaceOnUse">
-                <path d="M0,10 Q5,0 10,10" fill="none" stroke="#3fa66b" strokeWidth="1" />
-              </pattern>
-            </defs>
-            <rect x="0" y="0" width="600" height="360" fill="url(#g1)" />
-            <g transform="translate(300,180)">
-              <ellipse cx="0" cy="0" rx="120" ry="140" fill="#e5e7eb" stroke="#0c1220" strokeWidth="4" />
-              <line x1="0" y1="-140" x2="0" y2="140" stroke="#0c1220" strokeWidth="4" />
-              <clipPath id="rightHalf">
-                <rect x="0" y="-160" width="160" height="320" />
-              </clipPath>
-              <g clipPath="url(#rightHalf)">
-                <ellipse cx="0" cy="0" rx="120" ry="140" fill="#0f3b33" />
-                <ellipse cx="50" cy="-10" rx="26" ry="18" fill="#d6b410" stroke="#0b1220" strokeWidth="4" />
-                <circle cx="58" cy="-10" r="6" fill="#0b1220" />
-                <rect x="-120" y="-140" width="240" height="280" fill="url(#scales)" opacity="0.4" />
-              </g>
-              <clipPath id="leftHalf">
-                <rect x="-160" y="-160" width="160" height="320" />
-              </clipPath>
-              <g clipPath="url(#leftHalf)">
-                <ellipse cx="0" cy="0" rx="120" ry="140" fill="#cbd5e1" />
-                <ellipse cx="-50" cy="-12" rx="22" ry="14" fill="#1e293b" />
-                <circle cx="-52" cy="-12" r="5" fill="#93c5fd" />
-              </g>
-              <path d="M-30,50 Q0,70 30,50" stroke="#0b1220" strokeWidth="7" fill="none" strokeLinecap="round" />
-            </g>
-            <text
-              x="300"
-              y="330"
-              textAnchor="middle"
-              fill="#dee2e6"
-              style={{ fontFamily: "ui-sans-serif", fontSize: 18, fontWeight: 800 }}
-            >
-              반은 인간, 반은 랩틸리언
-            </text>
-          </svg>
+          <div style={styles.heroWrap}>
+            <img
+              src="./hero-face.svg"
+              alt="반은 인간, 반은 랩틸리언"
+              style={styles.heroImage}
+            />
+            <div style={styles.heroCaption}>반은 인간, 반은 랩틸리언</div>
+          </div>
         );
       }
 
@@ -548,6 +407,30 @@
           color: "#e5e7eb",
           position: "relative",
           overflow: "hidden",
+        },
+        heroWrap: {
+          width: "min(92vw, 820px)",
+          maxWidth: 900,
+          borderRadius: 16,
+          border: "1px solid rgba(255,255,255,0.12)",
+          background: "linear-gradient(180deg,#070a13,#0a0f1f)",
+          padding: 24,
+          boxSizing: "border-box",
+          display: "grid",
+          justifyItems: "center",
+          gap: 18,
+        },
+        heroImage: {
+          width: "100%",
+          height: "auto",
+          display: "block",
+        },
+        heroCaption: {
+          fontFamily: "ui-sans-serif",
+          fontSize: 18,
+          fontWeight: 800,
+          letterSpacing: 1,
+          color: "#dee2e6",
         },
         titleBox: { textAlign: "center", marginTop: 16 },
         btnPrimary: {


### PR DESCRIPTION
## Summary
- remove the static "잠입자 의심 신고서" heading and let the embedded game fill the viewport
- add a shared reptilian face SVG and display it on the intro screen hero panel
- style the final encounter to run in fullscreen with the same reptilian art and toggle scrolling appropriately

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e3e693f7888320871471afe9c7e6fe